### PR TITLE
Indicate we have Australian and US offices

### DIFF
--- a/src/css/pages/company.less
+++ b/src/css/pages/company.less
@@ -1,5 +1,5 @@
 .map {
   display: inline-block;
-  margin: 0 auto 0 0;
+  margin: 0 auto 1em 0;
   box-shadow: @shadow-default;
 }

--- a/src/html/company/index.html
+++ b/src/html/company/index.html
@@ -25,7 +25,7 @@ navbar: company
         <dt>Headquarters</dt>
         <dd>
           <div class="vcard">
-            <p class="adr">
+            <div class="adr">
               <span class="org fn">
                 <span class="organization-name">
                   Underscore
@@ -36,9 +36,13 @@ navbar: company
               <span class="region">Brighton</span>
               <span class="postal-code">BN1 4EW</span><br>
               <span class="country-name">UK</span>
-            </p>
-            <p><a target="_new" href="http://maps.google.com/maps?f=q&amp;source=embed&amp;hl=en&amp;geocode=&amp;q=6+Gloucester+Road,+Brighton,+BN1+4EW&amp;aq=&amp;sll=50.827034,-0.136393&amp;sspn=0.012162,0.013518&amp;g=6+Gloucester+Road,+Brighton,+BN1+4EW&amp;ie=UTF8&amp;hq=&amp;hnear=6+Gloucester+Road,+Brighton,+BN1+4EW&amp;ll=50.827034,-0.136393&amp;spn=0.011722,0.027788&amp;t=m&amp;z=14">View on map</a></p>
+            </div>
           </div>
+        </dd>
+
+        <dt>Directions</dt>
+        <dd>
+          <a target="_new" href="http://maps.google.com/maps?f=q&amp;source=embed&amp;hl=en&amp;geocode=&amp;q=6+Gloucester+Road,+Brighton,+BN1+4EW&amp;aq=&amp;sll=50.827034,-0.136393&amp;sspn=0.012162,0.013518&amp;g=6+Gloucester+Road,+Brighton,+BN1+4EW&amp;ie=UTF8&amp;hq=&amp;hnear=6+Gloucester+Road,+Brighton,+BN1+4EW&amp;ll=50.827034,-0.136393&amp;spn=0.011722,0.027788&amp;t=m&amp;z=14">Google Maps</a>
         </dd>
       </dl>
 
@@ -62,10 +66,13 @@ navbar: company
     <div class="col-sm-6">
       <h2>Find us</h2>
 
-      <p>Underscore has offices in the US, UK, and Australia. Please direct all enquiries to the UK office.</p>
+      <p>
+        Underscore has offices in the UK, US, and Australia.<br>
+      </p>
 
       <img class="map" src="http://maps.googleapis.com/maps/api/staticmap?size=410x410&amp;zoom=1&amp;markers=color:red%7C%7C50.827034,-0.136393|34.633018,-117.814121|-33.874492,151.209450&amp;sensor=false">
 
+      <p>All enquiries should be directed to our UK office.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Changed text to indicate Brighton office is our headquarters, and we
have others in US and Australia.

Changed "Find us" imagine to indicate global locations (vaguely).

Closes #12
