### PR TITLE
Work-around for Do Not Track mode

### DIFF
--- a/src/html/books/index.html
+++ b/src/html/books/index.html
@@ -11,7 +11,7 @@ navbar: books
     <div class="row">
       {% for bookId in site.data.books %}
         {% for book in site.books %}
-        <!-- 
+        <!--
           book.id is /books/creative-scala (for example)
           bookId is creative-scala (for example)
           So to compare we prepend /books/ to the bookId:

--- a/src/js/booking-form.coffee
+++ b/src/js/booking-form.coffee
@@ -1,6 +1,7 @@
 $           = require 'jquery'
 _           = require 'underscore'
 queryString = require './query-string'
+doNotTrack  = require './do-not-track'
 
 init = (elem) ->
 
@@ -121,7 +122,7 @@ init = (elem) ->
 
     form.find("button[type=submit]").on 'click', (evt) ->
       evt.preventDefault()
-      window.ga 'send', 'event', 'booking', 'submit', hitCallback: ->
+      doNotTrack.sendGaEvent 'booking', 'submit', undefined, ->
         onFormSubmission()
         return
       return

--- a/src/js/contact-form.coffee
+++ b/src/js/contact-form.coffee
@@ -1,6 +1,7 @@
 $           = require 'jquery'
 _           = require 'underscore'
 queryString = require './query-string'
+doNotTrack  = require './do-not-track'
 
 init = (elem) ->
 
@@ -89,7 +90,7 @@ init = (elem) ->
 
     form.find("button[type=submit]").on 'click', (evt) ->
       evt.preventDefault()
-      window.ga 'send', 'event', 'contact', 'submit', hitCallback: ->
+      doNotTrack.sendGaEvent 'contact', 'submit', undefined, ->
         onFormSubmission()
         return
       return

--- a/src/js/do-not-track.coffee
+++ b/src/js/do-not-track.coffee
@@ -1,0 +1,16 @@
+_ = require 'underscore'
+
+# If the browser has "Do Not Track" set,
+# ga("send", "event", ...) never calls our hitCallback function.
+#
+# We test window.ga.loaded to check whetner DNT is enabled,
+# and bypass Google Analytics if it is.
+sendGaEvent = (category, action, label = undefined, hitCallback = (->)) ->
+  if window.ga?.loaded
+    window.ga('send', 'event', category, action, label, { hitCallback })
+  else
+    hitCallback()
+
+module.exports = {
+  sendGaEvent
+}

--- a/src/js/ga-link.coffee
+++ b/src/js/ga-link.coffee
@@ -1,12 +1,14 @@
-$ = require "jquery"
-_ = require "underscore"
+$          = require "jquery"
+_          = require "underscore"
+doNotTrack = require './do-not-track'
+
 
 init = (sel = "body") ->
   root = $(sel)
 
   root.on "click", ".ga-link", (evt) ->
     # This code will cancel clicks on the application link if GA isn't present:
-    unless window.ga then return
+    unless window.ga?.loaded then return
 
     # Gather the click-through URL and tracking ID from the element:
     elem     = $(evt.currentTarget)
@@ -24,11 +26,9 @@ init = (sel = "body") ->
 
     # Record a custom "job application outbound" event on GA and
     # continue to the application link:
-    window.ga('send', 'event', category, action, label, {
-      hitCallback: ->
-        document.location = url
-        return
-    })
+    doNotTrack.sendGaEvent category, action, label, ->
+      document.location = url
+      return
 
     return
 


### PR DESCRIPTION
Don't try to send events to Google Analytics. Fixes #107.
