### PR TITLE
Add job expiry

### DIFF
--- a/src/html/_jobs/2015-04-guardian-backend-developer.md
+++ b/src/html/_jobs/2015-04-guardian-backend-developer.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Software Developer
 company: The Guardian
 level: Intermediate or Senior

--- a/src/html/_jobs/2015-04-mclaren-scala-software-engineer.md
+++ b/src/html/_jobs/2015-04-mclaren-scala-software-engineer.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Software Engineer
 company: McLaren Applied Technologies
 level: Intermediate

--- a/src/html/_jobs/2015-05-20-guardian-content-api.md
+++ b/src/html/_jobs/2015-05-20-guardian-content-api.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Content API Server-Side Engineer
 company: The Guardian
 level: Junior, Intermediate, Senior

--- a/src/html/_jobs/2015-05-20-guardian-discussion.md
+++ b/src/html/_jobs/2015-05-20-guardian-discussion.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Discussion Server-Side Engineer
 company: The Guardian
 location: London, UK

--- a/src/html/_jobs/2015-05-20-twilio-principal-software-engineer.md
+++ b/src/html/_jobs/2015-05-20-twilio-principal-software-engineer.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Principal Software Developer, Billing & Payments Infrastructure
 company: Twilio
 level: Senior

--- a/src/html/_jobs/2015-06-01-lunatech.md
+++ b/src/html/_jobs/2015-06-01-lunatech.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Senior Scala Developer
 company: Lunatech
 level: Intermediate, Senior

--- a/src/html/_jobs/2015-06-15-sitetour.md
+++ b/src/html/_jobs/2015-06-15-sitetour.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Software Engineer
 company: Site Tour
 level: Intermediate, Senior

--- a/src/html/_jobs/2015-06-18-permutive.md
+++ b/src/html/_jobs/2015-06-18-permutive.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Software Engineer
 company: Permutive
 level: Junior, Intermediate, Senior

--- a/src/html/_jobs/2015-07-01-elmar-full-stack.md
+++ b/src/html/_jobs/2015-07-01-elmar-full-stack.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Full Stack Developer
 company: Elmar Reizen
 level: Intermediate, Senior

--- a/src/html/_jobs/2015-07-01-ordina-scala-developer.md
+++ b/src/html/_jobs/2015-07-01-ordina-scala-developer.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Developer
 company: Ordina
 level: Intermediate, Senior

--- a/src/html/_jobs/2015-07-03-compellon.md
+++ b/src/html/_jobs/2015-07-03-compellon.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Senior Analytics Engineer
 company: Compellon
 level: Senior

--- a/src/html/_jobs/2015-07-21-minutekey.md
+++ b/src/html/_jobs/2015-07-21-minutekey.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Developer
 company: MinuteKEY
 level: Intermediate

--- a/src/html/_jobs/2015-07-21-workday.md
+++ b/src/html/_jobs/2015-07-21-workday.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Java/Scala Software Engineer
 company: Workday
 level: Junior, Intermediate, Senior

--- a/src/html/_jobs/2015-08-07-sweetspot.md
+++ b/src/html/_jobs/2015-08-07-sweetspot.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Back–End Software Engineer
 company: SweetSpot Diabetes
 level: Senior

--- a/src/html/_jobs/2015-08-27-tapad.md
+++ b/src/html/_jobs/2015-08-27-tapad.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Senior Scala Developer
 company: Tapad
 location: New York City, NY

--- a/src/html/_jobs/2015-09-01-nap.md
+++ b/src/html/_jobs/2015-09-01-nap.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Developer
 company: The Net-A-Porter Group
 level: Junior, Intermediate, Senior

--- a/src/html/_jobs/2015-10-28-itv-junior.md
+++ b/src/html/_jobs/2015-10-28-itv-junior.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Junior Scala Developer
 company: ITV
 location: London, UK

--- a/src/html/_jobs/2015-10-28-itv-senior.md
+++ b/src/html/_jobs/2015-10-28-itv-senior.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Senior Scala Developer
 company: ITV
 location: London, Grays Inn Road

--- a/src/html/_jobs/2015-10-30-mewe.md
+++ b/src/html/_jobs/2015-10-30-mewe.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Senior Scala Developer
 company: Sgrouples Inc.
 location: Worldwide

--- a/src/html/_jobs/2015-11-13-superawesome.md
+++ b/src/html/_jobs/2015-11-13-superawesome.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Developer
 company: SuperAwesome
 location: London

--- a/src/html/_jobs/2015-12-10-tozny.md
+++ b/src/html/_jobs/2015-12-10-tozny.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Server-Side Scala Developers
 company: Tozny
 location: Portland, OR, USA

--- a/src/html/_jobs/2015-12-22-datareply.md
+++ b/src/html/_jobs/2015-12-22-datareply.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Big Data Engineer
 company: Data Reply
 location: London

--- a/src/html/_jobs/2016-02-05-futureheads.md
+++ b/src/html/_jobs/2016-02-05-futureheads.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Contract Scala Developer
 company: Futureheads
 location: London

--- a/src/html/_jobs/2016-03-18-ee.md
+++ b/src/html/_jobs/2016-03-18-ee.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Developer
 company: Equal Experts
 location: Worthing, UK

--- a/src/html/_jobs/2016-04-08-itv.md
+++ b/src/html/_jobs/2016-04-08-itv.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Senior/Lead Software Engineer (Scala/Java)
 company: ITV
 location: Leeds, UK

--- a/src/html/_jobs/2016-05-13-apple.md
+++ b/src/html/_jobs/2016-05-13-apple.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Software Engineer, Software Automation
 company: Apple
 location:  Cupertino, California, United States

--- a/src/html/_jobs/2016-05-13-teralytics.md
+++ b/src/html/_jobs/2016-05-13-teralytics.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Developer (4 positions)
 company: Teralytics AG
 location: Zürich, Switzerland

--- a/src/html/_jobs/2016-06-07-call_handling.md
+++ b/src/html/_jobs/2016-06-07-call_handling.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Senior Scala Developer
 company: Call Handling
 location:  London, UK

--- a/src/html/_jobs/2016-07-07.md
+++ b/src/html/_jobs/2016-07-07.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Software Engineer (Scala)
 company: ITV
 location: London, UK

--- a/src/html/_jobs/2016-07-26-bastille.md
+++ b/src/html/_jobs/2016-07-26-bastille.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Software Engineer
 company: Bastille
 location: San Francisco 

--- a/src/html/_jobs/2016-07-26-cake.md
+++ b/src/html/_jobs/2016-07-26-cake.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Software Engineer - Scala
 company: Cake Solutions
 location: Manchester, UK

--- a/src/html/_jobs/2016-07-28-akanoo-gmbh.md
+++ b/src/html/_jobs/2016-07-28-akanoo-gmbh.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Software Engineer (Scala, Akka)
 company: |
   Akanoo GmbH

--- a/src/html/_jobs/2016-08-19-eyeem.md
+++ b/src/html/_jobs/2016-08-19-eyeem.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Backend Engineer (m/f)
 company: |
   EyeEm

--- a/src/html/_jobs/2016-08-24-pure360.md
+++ b/src/html/_jobs/2016-08-24-pure360.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Lead Scala Developer
 company: |
   Pure360

--- a/src/html/_jobs/2016-08-25-digital-genius.md
+++ b/src/html/_jobs/2016-08-25-digital-genius.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Mid Level Scala Software Engineer
 company: |
   Digital Genius

--- a/src/html/_jobs/2016-08-31-flynt.md
+++ b/src/html/_jobs/2016-08-31-flynt.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Senior Scala Developer 
 company: |
   Flynt 

--- a/src/html/_jobs/2016-09-12-rms.md
+++ b/src/html/_jobs/2016-09-12-rms.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Developer, Capital Markets
 company: |
   RMS

--- a/src/html/_jobs/2016-09-22-zalando-se.md
+++ b/src/html/_jobs/2016-09-22-zalando-se.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Software Engineer (f/m), Backend
 company: |
   Zalando SE

--- a/src/html/_jobs/2016-09-27-acorns.md
+++ b/src/html/_jobs/2016-09-27-acorns.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-01
 title: Scala Engineer
 company: |
   Acorns

--- a/src/html/_jobs/2016-10-15-banno-jha.md
+++ b/src/html/_jobs/2016-10-15-banno-jha.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-15
 title: Scala Software Engineer
 company: |
   Banno - JHA 

--- a/src/html/_jobs/2016-10-20-adstream.md
+++ b/src/html/_jobs/2016-10-20-adstream.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-20
 title: Scala Developer
 company: |
   Adstream

--- a/src/html/_jobs/2016-10-24-ovo-energy.md
+++ b/src/html/_jobs/2016-10-24-ovo-energy.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-24
 title: Scala Developer
 company: |
   OVO Energy

--- a/src/html/_jobs/2016-10-25-centro.md
+++ b/src/html/_jobs/2016-10-25-centro.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-25
 title: Data Engineer
 company: |
   Centro

--- a/src/html/_jobs/2016-10-28-fyber-gmbh.md
+++ b/src/html/_jobs/2016-10-28-fyber-gmbh.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-11-28
 title: Senior Scala Developer
 company: |
   Fyber GmbH

--- a/src/html/_jobs/2016-11-04-synereo.md
+++ b/src/html/_jobs/2016-11-04-synereo.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-12-04
 title: Core Team Member
 company: |
   Synereo

--- a/src/html/_jobs/2016-11-07-quantexa.md
+++ b/src/html/_jobs/2016-11-07-quantexa.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-12-07
 title: Software Engineer
 company: |
   Quantexa

--- a/src/html/_jobs/2016-11-08-boomtown.md
+++ b/src/html/_jobs/2016-11-08-boomtown.md
@@ -1,5 +1,6 @@
 ---
 layout: job
+expire: 2016-12-01
 title: Scala Developer
 company: |
   BoomTown

--- a/src/html/jobs/index.md
+++ b/src/html/jobs/index.md
@@ -15,9 +15,13 @@ navbar: jobs
 {% include jobs/links.html %}
 
 <article class="job-listing">
+  {% assign today = 'now' | date: '%s' %}
   {% assign jobs = site.jobs | sort: 'url' %}
   {% for job in jobs reversed %}
-  {% include jobs/excerpt.html job=job %}
+    {% assign expires = job.expire | date: '%s' %}
+      {% if expires > today %}
+        {% include jobs/excerpt.html job=job %}
+      {% endif %}
   {% endfor %}
 </article>
 


### PR DESCRIPTION
This PR:

- adds an `expire` date field to all jobs
- modifies the job listings page to only list non-expired jobs
