### PR TITLE
Note the missing audio on E. Slick video

### DIFF
--- a/src/_books/essential-slick.md
+++ b/src/_books/essential-slick.md
@@ -83,7 +83,10 @@ Dave Gurnell ran a hands-on workshop at Scala Exchange 2015 based on the materia
 - 1:17:30 - *Joins.* Selecting data from multiple tables.
 - 1:34:50 - *Profiles.* Selecting profiles,  writing database-generic code.
 
+Due to a problem with the recording, the video is missing five minutes of audio around the 45 minutes mark.
+
 The slides and sample code for the workshop can be found [on our Github account][github]. If you have trouble with any of the exercises or getting set up, feel free to ask questions [on our Gitter channel][gitter].
+
 
 [github]: https://github.com/underscoreio/scalax15-slick
 [gitter]: https://gitter.im/underscoreio/scalax15-slick

--- a/src/_courses/essential-slick.md
+++ b/src/_courses/essential-slick.md
@@ -59,6 +59,8 @@ Dave Gurnell ran a hands-on workshop at Scala Exchange 2015 based on the materia
 - 1:17:30 - *Joins.* Selecting data from multiple tables.
 - 1:34:50 - *Profiles.* Selecting profiles,  writing database-generic code.
 
+Due to a problem with the recording, the video is missing five minutes of audio around the 45 minutes mark.
+
 The slides and sample code for the workshop can be found [on our Github account][github]. If you have trouble with any of the exercises or getting set up, feel free to ask questions [on our Gitter channel][gitter].
 
 [github]: https://github.com/underscoreio/scalax15-slick


### PR DESCRIPTION
A second person has noted the ESlick video is missing a chunk of audio.  This PR may head off future comments. It looks like this:

![essential slick - underscore 2017-10-04 20-07-38](https://user-images.githubusercontent.com/102661/31194744-03ca38d6-a940-11e7-8584-f81be0a8ea7f.png)


Comment: [October 4, 2017 7:38 PM](https://gitter.im/underscoreio/scalax15-slick?at=59d52abc210ac26920a9756c)
